### PR TITLE
fix: removed cache from `get_my_points`

### DIFF
--- a/natour/api/views/users.py
+++ b/natour/api/views/users.py
@@ -321,7 +321,6 @@ def get_user_points(request, user_id):
 
 
 @get_my_points_schema
-@cache_page(60)
 @vary_on_headers("Authorization")
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])


### PR DESCRIPTION
Removed cache to see if it was responsible for always showing the same point count whenever a point was delted by the user